### PR TITLE
Allow non-JSON requests to be made, and a bug fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,5 +28,5 @@ xhr(uri, { jsonp: true }, function(err, data) {
 
 ## Options
 
-* *jsonp*: if true, then a callback is sent to the server and the output is parsed.  default: false
-
+* `json`: if true, the data is parsed as JSON when it comes back from the server. *default*: `true`
+* `jsonp`: if true, then a callback is sent to the server and the output is parsed. *default*: `false`

--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ var jsonp = function(uri, done) {
 
 var xhr = function(uri, done) {
   http.get(uri, function (res) {
-    var buf = null;
+    var buf = '';
 
     res.on('data', function (data) {
       buf += data;

--- a/index.js
+++ b/index.js
@@ -47,15 +47,27 @@ var xhr = function(uri, done) {
     });
 
     res.on('end', function () {
-      done(JSON.parse(buf));
+      done(buf);
     });
+  });
+};
+
+var json = function(uri, done) {
+  xhr(uri, function (buf) {
+    done(JSON.parse(buf));
   });
 };
 
 module.exports = function(uri, options, callback) {
   if (typeof(options) == 'function') {
     callback = options;
-    options = {};
+    options = {
+      json: true
+    };
+  } else if (typeof(options) == 'object') {
+    if (typeof(options.json) == 'undefined') {
+      options.json = true;
+    }
   }
 
   if (typeof(uri) === 'string') {
@@ -64,6 +76,9 @@ module.exports = function(uri, options, callback) {
 
   if (options.jsonp) {
     jsonp(uri, callback);
+  }
+  if (options.json) {
+    json(uri, callback);
   }
   else {
     xhr(uri, callback);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xhr-browserify",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Browserify compatible xhr module with support for jsonp",
   "main": "index.js",
   "scripts": {
@@ -10,6 +10,12 @@
     "type": "git",
     "url": "git://github.com/tommydudebreaux/xhr-browserify.git"
   },
+  "contributors": [
+    {
+      "name":"Daniel Hough",
+      "email":"daniel.hough@gmail.com"
+    }
+  ],
   "keywords": [
     "xhr",
     "browserify",


### PR DESCRIPTION
By using `{ json : false }` as the options object, the response can be returned as plain text instead of as JSON. Still defaults to `{ json : true }` so the interface is not broken for existing uses.

I also fixed a bug where the text "null" was being prepended to any response.
