### PR TITLE
Fix README to parseQueryString

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ JSONP
 
 ```
 var xhr = require('xhr-browserify');
-var uri = require('url').parse('http://www.foo.com/path/to/api?dogs=paws')
+var uri = require('url').parse('http://www.foo.com/path/to/api?dogs=paws', true);
 
 xhr(uri, { jsonp: true }, function(err, data) {
   console.log(data);


### PR DESCRIPTION
Per
http://nodejs.org/api/url.html#url_url_parse_urlstr_parsequerystring_slashesdenotehost,
the second argument to url.parse needs to be set to `true` in order to
parse the query string in the url. As it was, the README seemed to
indicate that ?dogs=paws would be parsed when it would not.
