### PR TITLE
Recognize option for custom jsonp callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,4 +29,5 @@ xhr(uri, { jsonp: true }, function(err, data) {
 ## Options
 
 * *jsonp*: if true, then a callback is sent to the server and the output is parsed.  default: false
+* *callbackName*: if jsonp is true, can be used to customize the jsonp callback.  default: 'callback'
 

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ var http = require('http');
 var jsonpCallbacks = {};
 var url = require('url');
 
-var jsonp = function (uri, done) {
+var jsonp = function(uri, callbackName, done) {
   var id;
   var fn;
 
@@ -21,7 +21,7 @@ var jsonp = function (uri, done) {
   // append jsonp callback to url
   delete uri.search;
   uri.query = uri.query || {};
-  uri.query.callback = id;
+  uri.query[callbackName] = id;
 
   // append callback
   var script = document.createElement('script');
@@ -70,7 +70,8 @@ module.exports = function (uri, options, callback) {
   }
 
   if (options.jsonp && typeof (window) != 'undefined') {
-    jsonp(uri, callback);
+    var callbackName = options.callbackName || 'callback';
+    jsonp(uri, callbackName, callback);
   } else {
     xhr(uri, callback);
   }


### PR DESCRIPTION
Not all servers respond to "callback". This patch adds support for a
custom `callbackName` option when using jsonp.
